### PR TITLE
Dockerize madprobe to give more flexibility to the app

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,23 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout madprobe
+      uses: actions/checkout@v2        
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag madjlzz/madprobe:${GITHUB_SHA::8}
+    - name: Login to DockerHub
+      run: printf $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
+      env:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Publish the Docker image
+      run: docker push registry-host:5000/myadmin/rhel-httpd

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag madjlzz/madprobe:${GITHUB_SHA::8}
     - name: Login to DockerHub
-      run: printf $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
+      run: echo -n $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
       env:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,9 +16,9 @@ jobs:
       uses: docker/build-push-action@v1.1.0
       with:
         # Username used to log in to a Docker registry. If not set then no login will occur
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        username: ${{ secrets.DOCKER_USERNAME }}
         # Password or personal access token used to log in to a Docker registry. If not set then no login will occur
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
         # Docker repository to tag the image with
         repository: madjlzz/madprobe
         # Automatically tags the built image with the git short SHA as per the readme

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,9 +12,14 @@ jobs:
     steps:
     - name: Checkout madprobe
       uses: actions/checkout@v2        
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag madjlzz/madprobe:${GITHUB_SHA::8}
-    - name: Login to DockerHub
-      run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-    - name: Publish the Docker image
-      run: docker push registry-host:5000/myadmin/rhel-httpd
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v1.1.0
+      with:
+        # Username used to log in to a Docker registry. If not set then no login will occur
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        # Password or personal access token used to log in to a Docker registry. If not set then no login will occur
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        # Docker repository to tag the image with
+        repository: madjlzz/madprobe
+        # Automatically tags the built image with the git short SHA as per the readme
+        tag_with_sha: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag madjlzz/madprobe:${GITHUB_SHA::8}
     - name: Login to DockerHub
-      run: echo -n $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
+      run: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
       env:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,9 +15,6 @@ jobs:
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag madjlzz/madprobe:${GITHUB_SHA::8}
     - name: Login to DockerHub
-      run: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-      env:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
     - name: Publish the Docker image
       run: docker push registry-host:5000/myadmin/rhel-httpd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.13 as builder
+WORKDIR /build/
+COPY . .
+RUN go get -v -t -d ./...
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o madprobe .
+
+FROM alpine:latest
+RUN addgroup -S golang && adduser -S golang -G golang
+USER golang:golang
+WORKDIR /opt/madprobe/
+COPY --from=builder /build/madprobe .
+CMD ["./madprobe"]


### PR DESCRIPTION
1. Configure GitHub action for the workflow.
2. Create Dockerfile to build the actual image.
3. Push to DockerHub https://hub.docker.com/repository/docker/madjlzz/madprobe